### PR TITLE
fix brand text

### DIFF
--- a/src/data/Nav.ts
+++ b/src/data/Nav.ts
@@ -1,6 +1,6 @@
 export const navLinks = [
   {
-    title: "IQ WIKI",
+    title: "IQ.wiki",
     href: "https://iq.wiki",
   },
   {


### PR DESCRIPTION
# Brand text correction

Replaced "IQ WIKI" to "IQ.wiki" for consistency and branding accuracy.

<img width="602" alt="image" src="https://github.com/EveripediaNetwork/braindao-ui/assets/67792966/0d4f0bd3-47b9-46f1-bf42-95ba8017c3b9">

closes https://github.com/EveripediaNetwork/issues/issues/1732
