### PR TITLE
fix: update footer X link to @IQofficial handle

### DIFF
--- a/src/components/layouts/Footer.tsx
+++ b/src/components/layouts/Footer.tsx
@@ -12,7 +12,7 @@ const products = [
 ];
 
 const socialLinks = [
-	{ name: "X", href: "https://x.com/IQAICOM" },
+	{ name: "X", href: "https://x.com/IQofficial" },
 	{ name: "Discord", href: "https://discord.com/invite/x9EWvTcPXt" },
 	{ name: "Telegram", href: "https://t.me/everipedia" },
 ];


### PR DESCRIPTION
## Description

Updates the footer social link for X (Twitter) to point to the official **@IQofficial** handle, replacing the legacy **@IQAICOM** handle.

`https://x.com/IQAICOM` → `https://x.com/IQofficial`

## Changes
- `src/components/layouts/Footer.tsx`: updated the `X` entry in `socialLinks` to the new handle.

## Related issue
Closes EveripediaNetwork/issues#5018